### PR TITLE
#7 - Change repo and app name to changelog.swm.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Screenshot](assets/screenshot_1.png "Screenshot")
 ![Screenshot](assets/screenshot_2.png "Screenshot")
 
-- [Site](https://theonlystephen.com)
+- [Site](https://changelog.swm.cc)
 
 ## Description
 
@@ -15,4 +15,4 @@ wanted the site to be. It also serves to describe the purpose of the site.
 For the time being all contribution links and descriptions are hand rolled, in
 time I will hopefully get the contributions from APIs and have it automated.
 
-For a list of future features please see the [Issue](https://github.com/swmcc/theonlystephen.com/issues) list.
+For a list of future features please see the [Issue](https://github.com/swmcc/changelog.swm.cc/issues) list.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# theonlystephen
+# changelog.swm.cc
 
 ![Screenshot](assets/screenshot_1.png "Screenshot")
 ![Screenshot](assets/screenshot_2.png "Screenshot")

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -9,8 +9,8 @@ date: 2021-03-18
 ### [swmcc/cookbook](https://github.com/swmcc/cookbook)
   - 📝 - Amended README.  ([#36d62f7](https://github.com/swmcc/cookbook/commit/36d62f7bc0d65aefceacaed13793d865fe6ca19e))
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs for 2023-03-06. ([#cd1a481](https://github.com/swmcc/theonlystephen.com/commit/cd1a48174ca6299a855f6e2f35211544b8673538)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs for 2023-03-06. ([#cd1a481](https://github.com/swmcc/changelog.swm.cc/commit/cd1a48174ca6299a855f6e2f35211544b8673538)) 
 
 # Change Log 
 
@@ -19,15 +19,15 @@ date: 2021-03-18
 ### [swmcc/links.swm.cc](https://github.com/swmcc/links.swm.cc)
   - 💄 - Added the mastodon link. ([#a5dfe21](https://github.com/swmcc/links.swm.cc/commit/a5dfe21c4faf880aab4c728275436bfaa81b0025))
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs for 2023-03-05. ([#84d3051](https://github.com/swmcc/theonlystephen.com/commit/84d3051461c8d82b4e7ca9c18ff8909e207b4cba)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs for 2023-03-05. ([#84d3051](https://github.com/swmcc/changelog.swm.cc/commit/84d3051461c8d82b4e7ca9c18ff8909e207b4cba)) 
 
 ## 2023-03-05
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlyswmcc)
-  - 🔀 [#3](https://github.com/swmcc/theonlystephen.com/issues/3) - Amend README to be useful. ([#4](https://github.com/swmcc/theonlystephen.com/pull/4))
-    - 📝 - Amended README. ([#3](https://github.com/swmcc/theonlystephen.com/issues/3)) - [#1a0233b](https://github.com/swmcc/theonlystephen.com/pull/4/commits/1a0233b1579589c54f51f284163d6954a1907570)
-  - 📝 - Added changelogs for 2023-03-04. ([#c1bb192](https://github.com/swmcc/theonlystephen.com/commit/c1bb192110cff7f7eb619389cecd704d640aa990)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/theonlyswmcc)
+  - 🔀 [#3](https://github.com/swmcc/changelog.swm.cc/issues/3) - Amend README to be useful. ([#4](https://github.com/swmcc/changelog.swm.cc/pull/4))
+    - 📝 - Amended README. ([#3](https://github.com/swmcc/changelog.swm.cc/issues/3)) - [#1a0233b](https://github.com/swmcc/changelog.swm.cc/pull/4/commits/1a0233b1579589c54f51f284163d6954a1907570)
+  - 📝 - Added changelogs for 2023-03-04. ([#c1bb192](https://github.com/swmcc/changelog.swm.cc/commit/c1bb192110cff7f7eb619389cecd704d640aa990)) 
 
 ## 2023-03-04
 
@@ -36,18 +36,18 @@ date: 2021-03-18
   - 🔧 - Added linux build platform. ([#cc7d9fb](https://github.com/swmcc/pulp/commit/cc7d9fb200830b089f7936c6d14d48dfca26c2d6)) 
   - 🎉 - Initial Commit. ([#bdc85f8](https://github.com/swmcc/pulp/commit/bdc85f8ec8b460f38ee91711de2b6b18dba3e80c))
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs for 2023-03-03. ([#598fcf2](https://github.com/swmcc/theonlystephen.com/commit/598fcf29a50a3b98a091c9b896d750b645fc0c3e)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs for 2023-03-03. ([#598fcf2](https://github.com/swmcc/changelog.swm.cc/commit/598fcf29a50a3b98a091c9b896d750b645fc0c3e)) 
 
 ## 2023-03-03
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs for 2023-03-02. ([#70571fa](https://github.com/swmcc/theonlystephen.com/commit/70571fae0ac5c50f8f5d18b6810f43a099091fc7)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs for 2023-03-02. ([#70571fa](https://github.com/swmcc/changelog.swm.cc/commit/70571fae0ac5c50f8f5d18b6810f43a099091fc7)) 
 
 ## 2023-03-02
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs for 2023-03-01. ([#5648376](https://github.com/swmcc/theonlystephen.com/commit/56483767da3e17c1c55b115e98aebe37aa07ed3e)) 
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs for 2023-03-01. ([#5648376](https://github.com/swmcc/changelog.swm.cc/commit/56483767da3e17c1c55b115e98aebe37aa07ed3e)) 
 
 ## 2023-03-01
 
@@ -55,15 +55,15 @@ date: 2021-03-18
   - 🚧 - Created file structure. ([#506fb55](https://github.com/swmcc/links.swm.cc/commit/506fb5528bdeef9f3b93a5f77e370a8a82044862))
 
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 📝 - Added changelogs from 2023-02-19 until 2023-02-28. ([#93b12e6](https://github.com/swmcc/theonlystephen.com/commit/93b12e61d4bdff382422c1ba5ad194875efbe8ae))
-  - 🚧 - Created file structure. ([#d080cfd](https://github.com/swmcc/theonlystephen.com/commit/d080cfdf30ce4196c8658b5396bef729630a015c))
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 📝 - Added changelogs from 2023-02-19 until 2023-02-28. ([#93b12e6](https://github.com/swmcc/changelog.swm.cc/commit/93b12e61d4bdff382422c1ba5ad194875efbe8ae))
+  - 🚧 - Created file structure. ([#d080cfd](https://github.com/swmcc/changelog.swm.cc/commit/d080cfdf30ce4196c8658b5396bef729630a015c))
 
 
 ## 2023-02-28
 
-### [swmcc/theonlystephen.com](https://github.com/swmcc/theonlystephen.com)
-  - 🎉 - Initial commit ([#686e6dc1](https://github.com/swmcc/theonlystephen.com/commit/686e6dc1f88f39dfd99e6e55183d81e18ed6b3af))
+### [swmcc/changelog.swm.cc](https://github.com/swmcc/changelog.swm.cc)
+  - 🎉 - Initial commit ([#686e6dc1](https://github.com/swmcc/changelog.swm.cc/commit/686e6dc1f88f39dfd99e6e55183d81e18ed6b3af))
 
 
 ## 2023-02-27
@@ -77,33 +77,33 @@ date: 2021-03-18
     - 🚨 - Amended code to suppress some pep8 warnings. ([#198997](https://github.com/thetvdb/tvdb-v4-python/pull/41/commits/198997729c249b24c25aa1056e08a2427dacd3be))
     - ♻️ - Amended code to use HTTPStatus and no longer hardcode ... ([#27533b0c](https://github.com/thetvdb/tvdb-v4-python/pull/41/commits/27533b0c5c884b4a38b9eba5f02c3c7a8d6589f2))
 
-### [the-mcculloughs.org](https://github.com/swm.cc/the-mcculloughs.org)
+### [swmcc/the-mcculloughs.org](https://github.com/swm.cc/the-mcculloughs.org)
 - 🧱 - Added platform for linux deployment. ([#94b6e78](https://github.com/swmcc/the-mcculloughs.org/commit/94b6e78))
 
 ## 2023-02-25
 
-### [swm.cc](https://github.com/swmcc/swm.cc)
+### [swmcc/swm.cc](https://github.com/swmcc/swm.cc)
 
 - 🔀 Now uses a new template. ([#8](https://github.com/swmcc/swm.cc/pull/8))
   - ✨ Amended documentation and added links back to the repo. ([#213e313](https://github.com/swmcc/swm.cc/commit/213e313))
 
 ## 2023-02-23
 
-### [swm.cc](https://github.com/swmcc/swm.cc)
+### [swmcc/swm.cc](https://github.com/swmcc/swm.cc)
 
 - 🔀 Added footer. Also added tailwind css. ([#3](https://github.com/swmcc/swm.cc/pull/6))
   - 📝 - Added footer. Also added tailwind css. ([#213e313](https://github.com/swmcc/swm.cc/commit/213e313))
 
 ## 2023-02-22
 
-### [stuffilearned](https://github.com/swmcc/stuffilearned)
+### [swmcc/stuffilearned](https://github.com/swmcc/stuffilearned)
 
 - 📝 - Added javascript directory. ([#614db60](https://github.com/swmcc/stuffilearned/commit/614db60))
 
 
 ## 2023-02-19
 
-### [swm.cc](https://github.com/swmcc/swm.cc)
+### [swmcc/swm.cc](https://github.com/swmcc/swm.cc)
 
 - 📝 - Amended documentation and added links back to the repo.  ([#cdca56f](https://github.com/swmcc/swm.cc/commit/cdca56fdae0)) 
 - 🚀 - Started to personalise. ([#9cea2af](https://github.com/swmcc/swm.cc/commit/9cea2af))


### PR DESCRIPTION
Re named app to be changelog.swm.cc from theonlystephen.com - also added changelogs and amended subdomains for both swm.cc and theonlystephen.com - www.theonlystephen.com now redirects to swm.cc